### PR TITLE
Update Copyright Section of Bylaws for Apache 2.0 License

### DIFF
--- a/bylaws.html
+++ b/bylaws.html
@@ -364,25 +364,26 @@ width="1000" height="129" /></p>
 <p>  The Consortium encourages all interested parties to bring to its attention, at the earliest possible time, the existence of any intellectual property rights pertaining to ITK. The Consortium invites any interested party to bring to its attention any copyrights, patents or patent applications, or other proprietary rights that may cover technology that may be in ITK.</p>
   
 <p>  The copyright applied to software, data, and or publications is shown in full in the following:</p>
-  
-  Copyright (c) 1999-2004 Insight Software Consortium<br/>
-  
-  All rights reserved.<br/>
-  
-<p>  Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:<br/>
-  
-  * Redistributions of source code must retain the above copyright notice, this list of conditions, and the following disclaimer.<br/>
-  
-  * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.<br/>
-  
-  * The name of the Insight Software Consortium, or the names of any consortium members, or of any contributors, may not be used to endorse or promote products derived from this software without specific prior written permission.<br/>
-  
-  * Modified source versions must be plainly marked as such, and must not be misrepresented as being the original software.<br/><br/>
-  
-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER AND CONTRIBUTORS ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</p>
-  
+<br/>
+<br/>
+
+  Copyright Insight Software Consortium<br>
+
+<p>Licensed under the Apache License, Version 2.0 (the "License");<br/>
+you may not use this file except in compliance with the License.<br/>
+You may obtain a copy of the License at<br/>
+<br>
+&nbsp; &nbsp; &nbsp; &nbsp;http://www.apache.org/licenses/LICENSE-2.0.txt</p>
+
+<p>Unless required by applicable law or agreed to in writing, software<br/>
+distributed under the License is distributed on an "AS IS" BASIS,<br/>
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.<br/>
+See the License for the specific language governing permissions and<br/>
+limitations under the License.<p/>
+<br/>
+<br/>
 <p>  See also the ITK web site: http://www.itk.org for more information.</p>
-  
+
 <div id="smalltitletext"> Article VIII</div><hr/>
   
 <p>  AMENDMENT OF BYLAWS</p>  


### PR DESCRIPTION
Thes move from the BSD license to the Apache 2.0 was discussed at the
October 2009 Insight Software Consortium Board Meeting, discussed until
December 14th, and the Board voted, during a period from December 15,
2009 to January 14th, 2010 to move to the Apache 2.0 License.