### PR TITLE
BUG: Use https for jquery download

### DIFF
--- a/citations.html
+++ b/citations.html
@@ -179,7 +179,7 @@ width="1000" height="129" /></p>
     <pre id="bibtex" style="display:none;">
 
         </pre>
-  	<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
+  	<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
 		<script type="text/javascript" src="citations/bib-list.js"></script>
 		<script type="text/javascript">
 		    $(document).ready(function() {


### PR DESCRIPTION
To address:

  citations.html:1 Mixed Content: The page at 'https://www.insightsoftwareconsortium.org/citations.html' was loaded over HTTPS, but requested an insecure script 'http://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js'. This request has been blocked; the content must be served over HTTPS.