### PR TITLE
DOC: Fix the development steps syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ http://www.apache.org/licenses/LICENSE-2.0
 
 ## Development
 
-1.  
+1.  **Create a new site.**
 
     Use the Gatsby CLI to create a new site, specifying the default starter.
 


### PR DESCRIPTION
Fix the development steps syntax: avoid the `Use the Gatsby CLI to create
a new site, specifying the default starter.` sentence being formatted to
a code block, and allow the `sh` language highlighting marker to be
invisible.