### PR TITLE
DOC: Update "Board of Directors" to "Council"

### DIFF
--- a/src/pages/council.js
+++ b/src/pages/council.js
@@ -49,7 +49,7 @@ const CouncilPage = () => {
           </li>
         </ul>
 
-        <p>The Board of Directors is:</p>
+        <p>Addition Council members are:</p>
         <ul>
           <li>Andras Lasso - Queen's University</li>
           <li>


### PR DESCRIPTION
Following corporate dissolution and NumFOCUS Sponsored Project status, this is the correct identification.