### PR TITLE
DOC: Do not track original ITK PI affiliations

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -87,13 +87,13 @@ const IndexPage = () => {
         <p>
           The Principal Investigators for these partners were, respectively,
           Bill Lorensen at GE CRD, Will Schroeder at Kitware, Vikram Chalana at
-          Insightful, Stephen Aylward with Luis Ibáñez at UNC (Stephen is now at
-          Kitware, Luis at Google), Ross Whitaker with Josh Cates at UT (both
-          now at Utah), and Dimitri Metaxas at UPenn. Additionally, several
+          Insightful, Stephen Aylward with Luis Ibáñez at UNC, Ross Whitaker with
+          Josh Cates at UT, and Dimitri Metaxas at UPenn. Additionally, several
           subcontractors rounded out the consortium including Peter Raitu at
           Brigham & Women's Hospital; Celina Imielinska and Pat Molholt at
           Columbia University; Jim Gee at UPenn's Grasp Lab; and George Stetten
-          at University of Pittsburgh.
+          at University of Pittsburgh. All institutions correspond to their
+          affiliations at the time.
         </p>
       </Typography>
 


### PR DESCRIPTION
Do not track original ITK PI affiliations: reduces maintenance, avoids outdated information (e.g. Stephen has recently moved to NVIDIA), avoids inconsistencies (some information was up-to-date, e.g. Luis being at Google, but other information was not, e.g. Dimitri is at Rutgers since 2001).