### PR TITLE
ENH: Fix workflow actions warnings linked to `Node.js`

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -9,10 +9,10 @@ jobs:
   build-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 20.x
 
       - name: Install build dependencies
         run: |


### PR DESCRIPTION
Fix format linter and spell check workflow actions warnings linked to `Node.js`: bump `actions/checkout` to `v4` and `actions/setup-node` to v4, and bump `node-version` to 20.x.

Fixes:
```
The following actions uses node12 which is deprecated and will be forced to run on node16:
 actions/setup-node@v1.
 For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

The following actions use a deprecated Node.js version and will be forced to run on node20:
 actions/checkout@v3, actions/setup-node@v1.
 For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```

raised for example in:
https://github.com/InsightSoftwareConsortium/insightsoftwareconsortium.org/actions/runs/11071188559